### PR TITLE
fix(ci): pin trivy-action to SHA after supply chain attack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             trivy-db-
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -153,7 +153,7 @@ jobs:
             trivy-db-
 
       - name: Run Trivy secret scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -185,7 +185,7 @@ jobs:
             trivy-db-
 
       - name: Run Trivy config scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'config'
           scan-ref: '.'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -129,7 +129,7 @@ jobs:
             trivy-db-
 
       - name: Run Trivy container scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: '${{ env.DOCKER_IMAGE }}:${{ steps.tag.outputs.value }}'
           severity: ${{ env.SECURITY_SEVERITY }}
@@ -168,7 +168,7 @@ jobs:
             trivy-db-
 
       - name: Generate SBOM
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: '${{ env.DOCKER_IMAGE }}:${{ steps.tag.outputs.value }}'
           format: 'cyclonedx'


### PR DESCRIPTION
## Summary

- **HIGH**: `aquasecurity/trivy-action` was compromised on 2026-03-19 (~19:00 UTC)
- Attackers force-pushed malicious code to 75 of 76 version tags (v0.0.1–v0.34.2) and `master`
- The malicious `entrypoint.sh` exfiltrates CI secrets to attacker-controlled infrastructure
- **This repo used `@0.28.0` (5 occurrences across `ci.yml` and `docker-build.yml`) — in compromised range**
- **No secrets were leaked** — no CI runs occurred after the compromise timestamp

## Changes

Pin all 5 `aquasecurity/trivy-action` references from `@0.28.0` to the SHA of v0.35.0 (`57a97c7e`), the only tag left untouched by attackers. SHA pinning prevents future tag-based attacks.

### Files modified
- `.github/workflows/ci.yml` — 3 occurrences
- `.github/workflows/docker-build.yml` — 2 occurrences

## Test plan

- [x] Verify no `@0.28.0` or other version-tag references remain: `grep -r "trivy-action" .github/`
- [x] CI workflow runs successfully with the pinned SHA
- [ ] Docker build workflow runs successfully with the pinned SHA